### PR TITLE
Add 棋弈江湖 - First open-source xiangqi board recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ All websites allow to play with other people and watch ongoing games.
 
 - [xiangqi-setup](https://github.com/hartwork/xiangqi-setup) - Python script to generate board images from FEN or WXF formats.
 - [xiangqi-book-example](https://github.com/hartwork/xiangqi-book-example) - LaTeX template to write text about xiangqi, using `xiangqi-setup` to generate board images from FEN notation.
+- [棋弈江湖 (Xiangqi PWA)](https://github.com/dffge552/xiangqi-pwa-offline) - Full-featured xiangqi platform with the world's first open-source board recognition system. Includes complete ONNX models for chess piece detection and classification, AI analysis powered by Pikafish, 7300+ puzzle database, and professional game review. All models are MIT licensed. [Live demo](https://android-xiangqi-offline.netlify.app/)
 
 ## Social
 


### PR DESCRIPTION
/Following up on issue #3 .

Adding 棋弈江湖 to the "Other useful tools" section.

**Project highlights:**
- 🌟 World's first open-source xiangqi board recognition system
- 🎯 Complete ONNX models (detection + classification) - ready to use
- 🤖 AI analysis powered by Pikafish  
- 📚 7300+ puzzle database
- 💾 Full PWA implementation (offline support)
- ⚖️ Automatic rule enforcement
- 📜 MIT licensed - free to use and retrain

**Live demo**: https://android-xiangqi-offline.netlify.app/

This fills a gap in the community as no other project has publicly released their trained computer vision models.

Thank you for maintaining this awesome list! Let me know if you'd like any changes.
