### PR TITLE
Add XiangqiOne to "Websites to play"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All websites allow to play with other people and watch ongoing games.
 | [ClubXiangqi](https://www.clubxiangqi.com/)  |                      no                      |         no         |     no      |                     discussion forum                     |
 |     [PyChess](https://www.pychess.org/)      |       fairy-stockfish, multiple levels       |  fairy-stockfish   |     yes     | supports other chess variants, some lessons and articles |
 |      [PlayOK](https://www.playok.com/)       |                      no                      |         no         |     no      |    supports also other chess variants and board games    |
+|      [XiangqiOne](https://xiangqi.one)       |          pikafish, multiple levels           |      pikafish      |     yes     |          mobile apps (iOS/Android), lessons              |
 
 ## Games databases
 


### PR DESCRIPTION
Hello, I'm from the XiangqiOne team, I would like to add our website to your awesome repository:

XiangqiOne is a free platform to play xiangqi online, against other players or against Pikafish at multiple levels, with an analysis board, puzzles and lessons. It's available on the web and as mobile apps (iOS/Android), and localized in 8 languages.

Thanks!