### PR TITLE
Add Mistboard to "Websites to play" and its board editor to "Other useful tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All websites allow to play with other people and watch ongoing games.
 |     [PyChess](https://www.pychess.org/)      |       fairy-stockfish, multiple levels       |  fairy-stockfish   |     yes     | supports other chess variants, some lessons and articles |
 |      [PlayOK](https://www.playok.com/)       |                      no                      |         no         |     no      |    supports also other chess variants and board games    |
 |      [XiangqiOne](https://xiangqi.one)       |          pikafish, multiple levels           |      pikafish      |     yes     |          mobile apps (iOS/Android), lessons              |
+|      [Mistboard](https://mistboard.com)      | pikafish, pikajieqi and fairy-stockfish, multiple levels |      pikafish      |     yes     | hidden information and flip variants (Fog Xiangqi, Jieqi, Banqi, Flip Jungle), games database, studies, board editor |
 
 ## Games databases
 
@@ -133,6 +134,7 @@ All websites allow to play with other people and watch ongoing games.
 - [xiangqi-setup](https://github.com/hartwork/xiangqi-setup) - Python script to generate board images from FEN or WXF formats.
 - [xiangqi-book-example](https://github.com/hartwork/xiangqi-book-example) - LaTeX template to write text about xiangqi, using `xiangqi-setup` to generate board images from FEN notation.
 - [棋弈江湖 (Xiangqi PWA)](https://github.com/dffge552/xiangqi-pwa-offline) - Full-featured xiangqi platform with the world's first open-source board recognition system. Includes complete ONNX models for chess piece detection and classification, AI analysis powered by Pikafish, 7300+ puzzle database, and professional game review. All models are MIT licensed. [Live demo](https://android-xiangqi-offline.netlify.app/)
+- [Mistboard board editor](https://mistboard.com/editor/xiangqi) - Browser board editor for xiangqi and several of its variants. Set up a position by hand or paste a FEN, then get a shareable link and a rendered position image.
 
 ## Social
 


### PR DESCRIPTION
Mistboard (https://mistboard.com) is a free xiangqi server. It has standard xiangqi against Pikafish at multiple levels, an analysis board, puzzles, a games database, studies, a board editor and live spectating. It also runs several hidden information and flip variants: Fog Xiangqi, Jieqi, Banqi and Flip Jungle.

Two changes:

- a row in the "Websites to play" table
- the board editor under "Other useful tools", since it does in a browser roughly what `xiangqi-setup` does as a script (position from a FEN, rendered board image). Happy to drop this one if it reads as duplicating the table row.

Disclosure: I built it. Happy to reword or drop either entry if it does not fit the list scope.